### PR TITLE
Allow ZLP control writes 

### DIFF
--- a/libusb/src/driver/ioctl.c
+++ b/libusb/src/driver/ioctl.c
@@ -669,7 +669,8 @@ NULL : input_buffer + sizeof(libusb_request),
 		dispCtlCode = "CONTROL_WRITE";
 
 		// check if the request and buffer is valid
-		if (!request || !transfer_buffer_mdl || input_buffer_length < sizeof(libusb_request))
+		// allow for zero length control packets
+		if (!request || (!transfer_buffer_mdl && transfer_buffer_length) || input_buffer_length < sizeof(libusb_request))
 		{
 			USBERR("%s: invalid transfer request\n", dispCtlCode);
 			status = STATUS_INVALID_PARAMETER;


### PR DESCRIPTION
Using for instance libusbk.dll 3.0.7.0 (the version currently installed with Zadig) a control transfer with zero length will fail (see libusb/libusb#1006). I suspect this is due to the check on transfer_buffer_mdl in src/driver/ioctl.c since the same check for bulk transfer write is explicitly not done. The second patch changes the control transfer check to be consistent to the bulk transfer check.

The first patch just adds missing debug tags. The second patch applies on top.

I don't have the setup to rebuild and test libusb0.sys so I can only assume this is correct without verification by own testing. BTW this issue doesn't show when using the recently released libusbk.dll 3.0.8.0 because the control transfers are done differently here.

Driver error message caught with DebugView:
`libusb0-sys:err [dispatch_ioctl] (null): invalid transfer request`