### PR TITLE
Rework IRP locking

### DIFF
--- a/libusb/Makefile
+++ b/libusb/Makefile
@@ -126,9 +126,14 @@ LIBWDI_DLL_LDFLAGS = -s -shared \
 	-Wl,--enable-stdcall-fixup \
 	-L. -lnewdev -lsetupapi -lole32
 
-DRIVER_LDFLAGS = -s -shared -Wl,--entry,_DriverEntry@8 \
+DRIVER_LDFLAGS = -s -shared -Wl,--entry,$(DRIVERENTRY) \
 	-nostartfiles -nostdlib -L. -lusbd -lntoskrnl -lhal
 
+ifneq (,$(findstring x86, $(host_prefix)))
+DRIVERENTRY = DriverEntry
+else
+DRIVERENTRY = _DriverEntry@8
+endif
 
 .PHONY: all
 all: dll filter test testwin

--- a/libusb/Makefile
+++ b/libusb/Makefile
@@ -35,6 +35,9 @@ endif
 ifdef cflags
 	DBG_DEFINE = $(cflags)
 endif
+ifdef ddk
+	DDK_INCLUDE = -I$(ddk)/include/ddk
+endif
 
 CC = $(host_prefix)gcc
 LD = $(host_prefix)ld
@@ -87,8 +90,10 @@ LIBWDI_OBJECTS = $(LIBWDI_DIR)/logging.5.o \
 				 
 
 INCLUDES = -I./src -I./src/driver -I.
+driver: INCLUDES += $(DDK_INCLUDE)
 
 CFLAGS = -O2 -Wall -DWINVER=0x500 $(DBG_DEFINE)
+CFLAGS += -Wno-unknown-pragmas -Wno-multichar
 WIN_CFLAGS = $(CFLAGS) -mwindows
 
 WINDRES_FLAGS = -I$(SRC_DIR)

--- a/libusb/src/driver/dispatch.c
+++ b/libusb/src/driver/dispatch.c
@@ -58,6 +58,10 @@ NTSTATUS DDKAPI dispatch(DEVICE_OBJECT *device_object, IRP *irp)
 
         case IRP_MJ_CREATE:
 
+            USBDBG("IRP_MJ_CREATE: is-filter=%c %s\n",
+                   dev->is_filter ? 'Y' : 'N',
+                   dev->device_id);
+
             if (dev->is_started)
             {
 				// only one driver can act as power policy owner and 
@@ -78,6 +82,10 @@ NTSTATUS DDKAPI dispatch(DEVICE_OBJECT *device_object, IRP *irp)
             }
 
         case IRP_MJ_CLOSE:
+
+            USBDBG("IRP_MJ_CLOSE: is-filter=%c %s\n",
+                   dev->is_filter ? 'Y' : 'N',
+                   dev->device_id);
 
             /* release all interfaces bound to this file object */
             release_all_interfaces(dev, stack_location->FileObject);

--- a/libusb/src/driver/driver_registry.c
+++ b/libusb/src/driver/driver_registry.c
@@ -19,6 +19,7 @@
 
 #include "libusb_driver.h"
 #include "lusb_defdi_guids.h"
+#include <guiddef.h>
 
 /* missing in mingw's ddk headers */
 #ifndef PLUGPLAY_REGKEY_DEVICE

--- a/libusb/src/driver/get_interface.c
+++ b/libusb/src/driver/get_interface.c
@@ -28,7 +28,6 @@ NTSTATUS get_interface(libusb_device_t *dev,
 {
     NTSTATUS status = STATUS_SUCCESS;
     URB urb;
-	PUSB_INTERFACE_DESCRIPTOR interface_descriptor;
 
 	USBMSG("interface: %d timeout: %d\n", interface_number, timeout);
 

--- a/libusb/src/driver/ioctl.c
+++ b/libusb/src/driver/ioctl.c
@@ -344,7 +344,7 @@ IoctlIsochronousWrite:
 		}
 		else
 		{
-			status = get_configuration(dev, output_buffer, &ret, request->timeout);
+			status = get_configuration(dev, (unsigned char *)output_buffer, &ret, request->timeout);
 		}
 		break;
 
@@ -370,7 +370,7 @@ IoctlIsochronousWrite:
 		status = get_interface(
 			dev,
 			request->intf.interface_number,
-			output_buffer, 
+			(unsigned char *)output_buffer,
 			request->timeout);
 
 		if (NT_SUCCESS(status))

--- a/libusb/src/driver/libusb_driver.c
+++ b/libusb/src/driver/libusb_driver.c
@@ -793,25 +793,25 @@ USB_INTERFACE_DESCRIPTOR* find_interface_desc_ex(USB_CONFIGURATION_DESCRIPTOR *c
 #define INTF_FIELD 0
 #define ALTF_FIELD 1
 
-	usb_descriptor_header_t *desc = (usb_descriptor_header_t *)config_desc;
+    usb_descriptor_header_t *desc = (usb_descriptor_header_t *)config_desc;
     char *p = (char *)desc;
-	int currentInfIndex;
-	short InterfacesByIndex[LIBUSB_MAX_NUMBER_OF_INTERFACES][2];
+    int currentInfIndex;
+    short InterfacesByIndex[LIBUSB_MAX_NUMBER_OF_INTERFACES][2];
 
     USB_INTERFACE_DESCRIPTOR *if_desc = NULL;
 
-	memset(InterfacesByIndex,0xFF,sizeof(InterfacesByIndex));
+    memset(InterfacesByIndex,0xFF,sizeof(InterfacesByIndex));
 
     if (!config_desc)
         return NULL;
 
-	size = size > config_desc->wTotalLength ? config_desc->wTotalLength : size;
+    size = size > config_desc->wTotalLength ? config_desc->wTotalLength : size;
 
     while (size && desc->length <= size)
     {
         if (desc->type == USB_INTERFACE_DESCRIPTOR_TYPE)
         {
-			// this is a new interface or alternate interface
+            // this is a new interface or alternate interface
             if_desc = (USB_INTERFACE_DESCRIPTOR *)desc;
 			for (currentInfIndex=0; currentInfIndex<LIBUSB_MAX_NUMBER_OF_INTERFACES;currentInfIndex++)
 			{

--- a/libusb/src/driver/libusb_driver.c
+++ b/libusb/src/driver/libusb_driver.c
@@ -795,7 +795,6 @@ USB_INTERFACE_DESCRIPTOR* find_interface_desc_ex(USB_CONFIGURATION_DESCRIPTOR *c
 
 	usb_descriptor_header_t *desc = (usb_descriptor_header_t *)config_desc;
     char *p = (char *)desc;
-	int lastInfNumber, lastAltNumber;
 	int currentInfIndex;
 	short InterfacesByIndex[LIBUSB_MAX_NUMBER_OF_INTERFACES][2];
 

--- a/libusb/src/driver/libusb_driver.h
+++ b/libusb/src/driver/libusb_driver.h
@@ -24,17 +24,14 @@
 //#define SKIP_DEVICES_WINUSB
 //#define SKIP_DEVICES_PICOPP
 
-#ifdef __GNUC__
-#include <ddk/usb100.h>
-#include <ddk/usbdi.h>
-#include <ddk/winddk.h>
-#include "usbdlib_gcc.h"
-#else
 #include <ntifs.h>
+#ifdef __GNUC__
+#define NTSTATUS LONG
+#else
 #include <wdm.h>
+#endif
 #include "usbdi.h"
 #include "usbdlib.h"
-#endif
 
 #include <wchar.h>
 #include <initguid.h>
@@ -44,19 +41,6 @@
 #include "driver_debug.h"
 #include "error.h"
 #include "driver_api.h"
-
-/* some missing defines */
-#ifdef __GNUC__
-
-#define USBD_TRANSFER_DIRECTION_OUT       0
-#define USBD_TRANSFER_DIRECTION_BIT       0
-#define USBD_TRANSFER_DIRECTION_IN        (1 << USBD_TRANSFER_DIRECTION_BIT)
-#define USBD_SHORT_TRANSFER_OK_BIT        1
-#define USBD_SHORT_TRANSFER_OK            (1 << USBD_SHORT_TRANSFER_OK_BIT)
-#define USBD_START_ISO_TRANSFER_ASAP_BIT  2
-#define USBD_START_ISO_TRANSFER_ASAP   (1 << USBD_START_ISO_TRANSFER_ASAP_BIT)
-
-#endif
 
 #define SET_CONFIG_ACTIVE_CONFIG -258
 
@@ -81,7 +65,9 @@
 #define LIBUSB_MAX_CONTROL_TRANSFER_TIMEOUT 5000
 
 
-#ifndef __GNUC__
+#ifdef __GNUC__
+#define DDKAPI __stdcall
+#else
 #define DDKAPI
 #endif
 
@@ -140,7 +126,9 @@ typedef int bool_t;
 
 #endif
 
+#ifndef __GNUC__
 #define USB_ENDPOINT_ADDRESS_MASK 0x0F
+#endif
 #define USB_ENDPOINT_DIR_MASK 0x80
 #define LBYTE(w) (w & 0xFF)
 #define HBYTE(w) ((w>>8) & 0xFF)

--- a/libusb/src/driver/lusb_defdi_guids.h
+++ b/libusb/src/driver/lusb_defdi_guids.h
@@ -2,13 +2,11 @@
 #define __LUSB_DEFDI_GUIDS_
 
 #ifndef DEFINE_TO_STR
-#define _DEFINE_TO_STR(x) #x
-#define  DEFINE_TO_STR(x) _DEFINE_TO_STR(x)
+#define  DEFINE_TO_STR(x) #x
 #endif
 
 #ifndef DEFINE_TO_STRW
-#define _DEFINE_TO_STRW(x) L#x
-#define  DEFINE_TO_STRW(x) _DEFINE_TO_STRW(x)
+#define  DEFINE_TO_STRW(x) L ## #x
 #endif
 
 #define DEFINE_DEVICE_INTERFACE_GUID(BaseFieldName,BaseGuidName,L1,W1,W2,B1,B2,B3,B4,B5,B6,B7,B8)	\

--- a/libusb/src/driver/set_configuration.c
+++ b/libusb/src/driver/set_configuration.c
@@ -30,7 +30,7 @@ NTSTATUS set_configuration(libusb_device_t *dev,
     USB_CONFIGURATION_DESCRIPTOR *configuration_descriptor = NULL;
     USB_INTERFACE_DESCRIPTOR *interface_descriptor = NULL;
     USBD_INTERFACE_LIST_ENTRY *interfaces = NULL;
-    int i, j, interface_number, desc_size, config_index, ret;
+    int i, j, interface_number, desc_size, config_index;
 
 	// check if this config value is already set
 	if ((configuration > 0) && dev->config.value == configuration)

--- a/libusb/src/driver/set_interface.c
+++ b/libusb/src/driver/set_interface.c
@@ -103,8 +103,6 @@ NTSTATUS set_interface_ex(libusb_device_t *dev,
 					   interface_request_t* interface_request, 
                        int timeout)
 {
-    NTSTATUS status = STATUS_SUCCESS;
-
     USB_INTERFACE_DESCRIPTOR *interface_descriptor = NULL;
 
 	USBMSG("interface-%s=%d alt-%s=%d timeout=%d\n",

--- a/libusb/src/driver/transfer.c
+++ b/libusb/src/driver/transfer.c
@@ -393,7 +393,6 @@ NTSTATUS large_transfer(IN libusb_device_t* dev,
 						IN PMDL mdlAddress,
 						IN int totalLength)
 {
-	PIO_STACK_LOCATION      irpStack;
 	BOOLEAN                 read;
 	ULONG                   stageSize;
 	ULONG                   numIrps;
@@ -424,7 +423,6 @@ NTSTATUS large_transfer(IN libusb_device_t* dev,
 	//
 	// initialize vars
 	//
-	irpStack = IoGetCurrentIrpStackLocation(irp);
 	sequenceID = InterlockedIncrement(&sequence);
 	subRequestContextArray = NULL;
 

--- a/libusb/src/driver/transfer.c
+++ b/libusb/src/driver/transfer.c
@@ -985,6 +985,7 @@ NTSTATUS large_transfer_complete(IN PDEVICE_OBJECT DeviceObjectIsNULL,
 			subRequestByteCount = MmGetMdlByteCount(subUrb->UrbBulkOrInterruptTransfer.TransferBufferMDL);
 			subRequestByteOffset = MmGetMdlByteOffset(subUrb->UrbBulkOrInterruptTransfer.TransferBufferMDL);
 			information = subUrb->UrbBulkOrInterruptTransfer.TransferBufferLength;
+			(void) subRequestByteOffset;
 			USBDBG("[%s #%d] offset=%d requested=%d transferred=%d\n", 
 				dispTransfer, 
 				sequenceID, 

--- a/libusb/src/error.c
+++ b/libusb/src/error.c
@@ -23,15 +23,7 @@
 #include <stdio.h>
 
 #if IS_DRIVER
-	#ifdef __GNUC__
-		#define OBJ_KERNEL_HANDLE       0x00000200L
-		#include <ddk/usb100.h>
-		#include <ddk/usbdi.h>
-		#include <ddk/winddk.h>
-		#include "usbdlib_gcc.h"
-	#else
-		#include <ntddk.h>
-	#endif
+	#include <ntddk.h>
 #else
 	#include <windows.h>
 #endif

--- a/libusb/src/install.c
+++ b/libusb/src/install.c
@@ -30,15 +30,9 @@
 #include <richedit.h>
 #include <conio.h>
 #include <ctype.h>
+#include <cfgmgr32.h>
 
-#ifdef __GNUC__
-#if  defined(_WIN64)
-#include <cfgmgr32.h>
-#else
-#include <ddk/cfgmgr32.h>
-#endif
-#else
-#include <cfgmgr32.h>
+#ifndef __GNUC__
 #define strlwr(p) _strlwr(p)
 #endif
 

--- a/libusb/src/install_filter_win.c
+++ b/libusb/src/install_filter_win.c
@@ -20,15 +20,9 @@
 #define INITGUID
 
 #include <windows.h>
+#include <cfgmgr32.h>
 
-#ifdef __GNUC__
-	#if  defined(_WIN64)
-		#include <cfgmgr32.h>
-	#else
-		#include <ddk/cfgmgr32.h>
-	#endif
-#else
-	#include <cfgmgr32.h>
+#ifndef __GNUC__
 	#define strlwr(p) _strlwr(p)
 #endif
 

--- a/libusb/src/registry.c
+++ b/libusb/src/registry.c
@@ -23,15 +23,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <cfgmgr32.h>
 
-#ifdef __GNUC__
-#if  defined(_WIN64)
-#include <cfgmgr32.h>
-#else
-#include <ddk/cfgmgr32.h>
-#endif
-#else
-#include <cfgmgr32.h>
+#ifndef __GNUC__
 #define strlwr(p) _strlwr(p)
 #endif
 


### PR DESCRIPTION
This is on top of my PR https://github.com/mcuee/libusb-win32/pull/36

Note this has only been minimally tested with xusb.exe so far.

- driver: Rework cancel and timeout handling in call_usbd_ex
This is based on the "text book" (the MS documentation referenced in the commit message)
The original code is using the same _event_ for 2 different purposes, which I think is wrong.

- driver: Allow synchronous return from lower driver in get_current_frame
Also just based on code review and MS documentation.

I am curious whether this (especially the call_usbd_ex patch) can help for issue https://github.com/libusb/libusb/issues/1255