### PR TITLE
Fix MinGW kernel driver build at least for pre-Win8

### DIFF
--- a/libusb/src/driver/libusb_driver.c
+++ b/libusb/src/driver/libusb_driver.c
@@ -386,6 +386,7 @@ NTSTATUS DDKAPI add_device(DRIVER_OBJECT *driver_object,
         return STATUS_NO_SUCH_DEVICE;
     }
 
+#if (NTDDI_VERSION >= NTDDI_WIN8)
     status = USBD_CreateHandle(device_object,
       dev->next_stack_device,
       USBD_CLIENT_CONTRACT_VERSION_602,
@@ -428,6 +429,10 @@ NTSTATUS DDKAPI add_device(DRIVER_OBJECT *driver_object,
             status = STATUS_SUCCESS;
         }
     }
+#else
+    dev->speed = FullSpeed;
+    status = STATUS_SUCCESS;
+#endif
 
     USBDBG("[%s] id=#%d %s, speed=%d\n", dev->is_filter ? "filter_mode" : "normal-mode", dev->id, dev->device_id, dev->speed);
 

--- a/libusb/src/driver/libusb_driver.c
+++ b/libusb/src/driver/libusb_driver.c
@@ -762,6 +762,20 @@ bool_t update_pipe_info(libusb_device_t *dev,
               maxTransferSize = 4 * 1024 * 1024;
               break;
 
+          case UsbdPipeTypeIsochronous:
+              switch (dev->speed)
+              {
+                  case SuperSpeed:
+                      // TODO: 1024 * wBytesPerInterval from USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR
+                  case HighSpeed:
+                      maxTransferSize = 1024 * interface_info->Pipes[i].MaximumPacketSize;
+                      break;
+                  default:
+                      maxTransferSize = 256 * interface_info->Pipes[i].MaximumPacketSize;
+                      break;
+              }
+              break;
+
           case UsbdPipeTypeBulk:
               switch (dev->speed)
               {

--- a/libusb/src/driver/libusb_driver.c
+++ b/libusb/src/driver/libusb_driver.c
@@ -393,7 +393,7 @@ NTSTATUS DDKAPI add_device(DRIVER_OBJECT *driver_object,
       &dev->handle);
     if (!NT_SUCCESS(status))
     {
-      USBERR("failed to create USBD handle\n");
+      USBERR0("failed to create USBD handle\n");
       IoDeleteSymbolicLink(&symbolic_link_name);
       IoDeleteDevice(device_object);
       remove_lock_release(dev); // always release acquired locks

--- a/libusb/src/driver/libusb_driver.h
+++ b/libusb/src/driver/libusb_driver.h
@@ -185,7 +185,9 @@ typedef struct
     DEVICE_OBJECT	*physical_device_object;
     DEVICE_OBJECT	*next_stack_device;
     DEVICE_OBJECT	*target_device;
-	USBD_HANDLE handle;
+#if (NTDDI_VERSION >= NTDDI_WIN8)
+    USBD_HANDLE handle;
+#endif
     libusb_remove_lock_t remove_lock;
     bool_t is_filter;
     bool_t is_started;

--- a/libusb/src/driver/pnp.c
+++ b/libusb/src/driver/pnp.c
@@ -73,8 +73,10 @@ NTSTATUS dispatch_pnp(libusb_device_t *dev, IRP *irp)
 		/* wait until all outstanding requests are finished */
         remove_lock_release_and_wait(dev);
 
+#if (NTDDI_VERSION >= NTDDI_WIN8)
 		/* Close handle to USBD */
 		USBD_CloseHandle(dev->handle);
+#endif
 
         status = pass_irp_down(dev, irp, NULL, NULL);
 

--- a/libusb/src/error.h
+++ b/libusb/src/error.h
@@ -99,7 +99,7 @@ enum USB_LOG_LEVEL
 	#define DEF_LOG_OUTPUT_TYPE LOG_OUTPUT_TYPE_STDERR
 #endif
 
-#define _usb_log_do_nothing() while(0)
+#define _usb_log_do_nothing() do {} while(0)
 // Default logging output
 #ifdef LOG_OUTPUT_TYPE
 	// all log messages (except errors) are stripped


### PR DESCRIPTION
There is some work to do to build with the new Win8 features on MinGW, but this at least allows building for Win7 and older.

Note that for instance MinGW 7 sets NTDDI_VERSION to 0x5020000 (NTDDI_WS03, thus before Win6) whereas MinGW 10 sets NTDDI_VERSION to 0xa000000 (NTDDI_WIN10), so to build with the latter, add e.g. `CFLAGS += -DNTDDI_VERSION=NTDDI_WIN7` to Makefile.